### PR TITLE
Don't disable 'Display' button on report chooser after form submission.

### DIFF
--- a/app/views/dossier/reports/_chooser.html.erb
+++ b/app/views/dossier/reports/_chooser.html.erb
@@ -11,7 +11,7 @@
     <%= select_tag 'options[period]',
                    options_for_select(@periods), { prompt: t(:Select_a_period, scope: :reports), class: 'form-control' } %>
   </div>
-  <%= submit_tag t(:Display), { class: 'btn btn-primary' } %>
+  <%= submit_tag t(:Display), { class: 'btn btn-primary', data: {disable_with: false} } %>
 
 </form>
 


### PR DESCRIPTION
Rails default is to disable form submit buttons after submitting, but since we don't always leave the page when viewing reports (DIPES Text Report at least), we need the Display button to stay active. Accidental double submissions are not a problem for this form.