### PR TITLE
Generate Timesheets for Selected Employees

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -47,6 +47,7 @@ class AdminController < ApplicationController
     @periods = []
     @current = Period.current()
     period = @current.next.next
+    @employees = Employee.currently_paid()
 
     (0..12).each do
       @periods << period
@@ -60,6 +61,17 @@ class AdminController < ApplicationController
     @today = Date.today
 
     period_param = params[:period]
+    @selected_employees = params[:employees]
+
+    if @selected_employees.nil?
+      redirect_to generate_timesheets_path, :notice => t(:You_must_select_one)
+      return
+    end
+
+    if period_param.nil? || period_param.length == 0
+      redirect_to generate_timesheets_path, :notice => t(:You_must_a_period)
+      return
+    end
 
     begin
       period_year, period_month = period_param.split('-')
@@ -72,7 +84,6 @@ class AdminController < ApplicationController
     @end_date = period.finish
 
     @announcement = params[:timesheet][:announcement]
-    @employees = Employee.currently_paid()
     @filename = 'eps-timesheet.pdf'
   end
 

--- a/app/views/admin/timesheet.html.erb
+++ b/app/views/admin/timesheet.html.erb
@@ -16,6 +16,12 @@
   </div>
 
   <div class="form-group">
+    <label><%= t :Employee %></label>
+    <%= select_tag 'employees',
+                    options_from_collection_for_select(@employees, 'id', 'full_name_rev', @employees.map(&:id)), { multiple: true, size: 10, class: 'form-control' } %>
+  </div>
+
+  <div class="form-group">
     <label><%= t :Announcements %></label>
     <%= text_area(:timesheet, :announcement, class: 'form-control') %>
   </div>

--- a/app/views/admin/timesheets.pdf.prawn
+++ b/app/views/admin/timesheets.pdf.prawn
@@ -7,7 +7,9 @@ prawn_document(page_layout: :landscape) do |pdf|
 
   holidays_hash = Holiday.days_hash(@start_date, @end_date)
 
-  @employees.each do |employee|
+  @selected_employees.each do |eid|
+
+    employee = Employee.find(eid)
 
     # Header
     pdf.text "SIL EMPLOYEE TIMESHEET", :align => :center, :style => :bold
@@ -105,11 +107,6 @@ prawn_document(page_layout: :landscape) do |pdf|
       pdf.font("Helvetica", :style => :italic, :size => 10) do
         pdf.text "Announcements: #{@announcement}"
       end
-    end
-
-    # Don't make an empty, blank page after the last employee
-    unless employee == @employees.last
-      pdf.start_new_page
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,8 @@ en:
   cant_change_paid_record: is in a vacation that is already paid.
   is_invalid: is invalid.
   You_must_select: You Must Select an Employee First
+  You_must_select_one: You must select at least one employee
+  You_must_a_period: You must select a period
 
   # Alerts
   Alerts: Alerts

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -70,6 +70,8 @@ fr:
   cant_change_paid_record: ne peut pas être changé, les vacances sont déjà payées.
   is_invalid: n'est pas valide.
   You_must_select: D'abord, Il faut choisir un employée
+  You_must_select_one: Il faut choisir au moins qu’un employé
+  You_must_a_period: Il faut choisir une période
 
   # Alerts
   Alerts: Avertissements


### PR DESCRIPTION
This changes allows all, one, or some employees to be selected for
generataion in the timesheet PDF file for printing and distributing
to employees. This change adds a multi-select on the timesheet page
with all currently paid employees selected by default.

Previously only a PDF for all employees could be generated.