### PR TITLE
Enter All Hours

### DIFF
--- a/app/assets/javascripts/work_hours.coffee
+++ b/app/assets/javascripts/work_hours.coffee
@@ -8,3 +8,8 @@ $(document).on "turbolinks:load", ->
       excuse_section.slideUp('fast')
       excuse_section.find('input.excused-hours-excuse').prop('disabled', true)
       excuse_section.find('input.excused-hours').val(0)
+
+$ ->
+  $('body').on 'click', '#fill-all-btn', ->
+    $('#fill-all-btn').html('Working...')
+    true

--- a/app/controllers/work_hours_controller.rb
+++ b/app/controllers/work_hours_controller.rb
@@ -49,6 +49,18 @@ class WorkHoursController < ApplicationController
     end
   end
 
+  def update_all
+    authorize! :admin, Employee
+
+    if params[:fill_all] == 'true'
+      WorkHour.employees_lacking_work_hours(LastPostedPeriod.current).each do |e|
+        WorkHour.fill_default_hours(e, LastPostedPeriod.current)
+      end
+
+      redirect_to work_hours_path()
+    end
+  end
+
   private
 
   def hour_params

--- a/app/views/work_hours/index.html.erb
+++ b/app/views/work_hours/index.html.erb
@@ -15,5 +15,27 @@
     </small>
   </h3>
 
-  <%= link_to t(:Enter_hours), edit_employee_work_hours_path(@employees_needing_entry.first, enter_all: true), class: 'btn btn-primary' %>
+  <div class="panel panel-default">
+    <div class="panel-heading"><%= t :Enter_hours_for_all %></div>
+    <div class="panel-body">
+      <%= link_to t(:Enter_hours), edit_employee_work_hours_path(@employees_needing_entry.first, enter_all: true), class: 'btn btn-primary' %>
+      <p class="help-block">
+        <%= t :Enter_hours_for_all_desc %><br />
+      </p>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading"><%= t :Fill_hours_for_all %></div>
+    <div class="panel-body">
+      <%= button_to(fill_all_employees_work_hours_path(fill_all: true), class: 'btn btn-warning', id: 'fill-all-btn') do %>
+        <%= t(:Fill_hours) %>
+      <% end %>
+      <br />
+      <p class="help-block">
+        <%= t :fill_hours_for_all_desc %><br />
+      </p>
+    </div>
+  </div>
+
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -227,6 +227,10 @@ en:
   Excused_hours: Excused Hours
   Reason: 'Reason:'
   hours_excused: hours excused.
+  Fill_hours: Fill Hours Automatically
+  Fill_hours_for_all: Automatically fill default hours for employees who need them
+  fill_hours_for_all_desc: "This option will automatically fill default hours for those employees whose hours have not yet been entered. This will not fill hours for holidays, weekends, or vacation days. Please verify the employee's hours against the employee's timesheet before processing payroll."
+  Enter_hours_for_all_desc: "This option will take you each employee's page one after the other where you can enter hours for each employee one after the other."
 
   # WorkLoans
   Work_loans: Work Loans

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -232,6 +232,11 @@ fr:
   Excused_hours: Heures excusés
   Reason: 'Raison :'
   hours_excused: heures excusés.
+  Fill_hours: Remplir les heures
+  Fill_hours_for_all: Remplir les heures par défaut automatiquement.
+  fill_hours_for_all_desc: "Cette option va remplir les heures par défaut pour chaque employé qui manquent des heures. Cette option ne va pas remplir des heures pour les jours fériés, les week-ends, ou les congés. Veuillez vérifier les heures de l'employé avec les feuilles de temps de chaque employé avant de créer les bulletins de paie."
+  Enter_hours_for_all: Saisir les heures employé par employé
+  Enter_hours_for_all_desc: Cette option va vous présenter la page des heures pour chaque employé qui manquent des heures. Vous devez vérifier chaque employé et taper le bouton avant de continuer au prochain.
 
   # WorkLoans
   Work_loans: Prêts de Travail

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,7 @@ Rails.application.routes.draw do
   get 'employees/:employee_id/work_hours',      to: 'work_hours#index', as: :employee_work_hours
   get 'employees/:employee_id/work_hours/edit', to: 'work_hours#edit',  as: :edit_employee_work_hours
   post 'employees/:employee_id/work_hours',    to: 'work_hours#update', as: :update_employee_work_hours
+  post 'employees/work_hours_fill_all', to: 'work_hours#update_all', as: :fill_all_employees_work_hours
 
   # Administration
   get 'admin/index'

--- a/test/controllers/payslips_controller_test.rb
+++ b/test/controllers/payslips_controller_test.rb
@@ -4,6 +4,8 @@ class PayslipsControllerTest < ActionDispatch::IntegrationTest
   include ControllerTestHelper
 
   def setup
+    Payslip.reset_column_information
+
     @luke = employees(:Luke)
     @han = employees(:Han)
     @obiwan = employees(:Obiwan)


### PR DESCRIPTION
Provide a button to enter default hours for all who need them. The
option to enter the hours employee by employee is still there. A
new function has been added to allow for filling default hours in
the model.

This should save time at the beginning of the month by allowing
a baseline to be entered and then modifications can be made to
the default hours as appropriate. This was how finance was using
the system anyways.