### PR TITLE
Round vacation_balance in Payslip calculations

### DIFF
--- a/app/models/payslip.rb
+++ b/app/models/payslip.rb
@@ -820,7 +820,7 @@ class Payslip < ApplicationRecord
       end
     end
 
-    if (cur_balance - vacation_days_used < 0)
+    if ((cur_balance.round(2) - vacation_days_used) < 0)
       Rails.logger.error("CB: #{cur_balance} less #{vacation_days_used} for period #{payslip.period}")
       raise Exception.new("Insufficient vacation balance to take this month's vacation, Please Correct.")
     end


### PR DESCRIPTION
Due to floating point errors (something else to look
into at some point) vacation balances sometimes are
19.9999999996, etc. Round this so it becomes 20 in
that case when comparing balances to requested amounts.